### PR TITLE
Set up basic Hugo site structure with shared styles

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Stabat Mater Collection"
+---
+Welcome to the Stabat Mater Collection. Explore compositions, composers, texts and translations of the Stabat Mater Dolorosa.

--- a/content/stabat-mater-composer/_index.md
+++ b/content/stabat-mater-composer/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Composers"
+---
+A growing directory of Stabat Mater composers. This page will eventually list composers and their works.

--- a/content/stabat-mater-foundation/_index.md
+++ b/content/stabat-mater-foundation/_index.md
@@ -1,0 +1,4 @@
+---
+title: "About the foundation"
+---
+The Ultimate Stabat Mater website Foundation aims to assist composers, musicians, and music lovers anywhere in the world.

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>{{ block "title" . }}{{ .Title }} - {{ .Site.Title }}{{ end }}</title>
+  <link rel="stylesheet" href="{{ "css/style.css" | relURL }}">
+</head>
+<body>
+  <header>
+    <nav>
+      <ul>
+        {{ range .Site.Menus.main }}
+        <li><a href="{{ .URL | relURL }}">{{ .Name }}</a></li>
+        {{ end }}
+      </ul>
+    </nav>
+  </header>
+  <main>
+    {{ block "main" . }}{{ end }}
+  </main>
+  <footer>
+    <p>&copy; {{ now.Format "2006" }} {{ .Site.Title }}</p>
+  </footer>
+</body>
+</html>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,0 +1,11 @@
+{{ define "main" }}
+  {{ if .Title }}<h1>{{ .Title }}</h1>{{ end }}
+  {{ .Content }}
+  {{ if .Pages }}
+  <ul>
+    {{ range .Pages }}
+    <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+    {{ end }}
+  </ul>
+  {{ end }}
+{{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,0 +1,6 @@
+{{ define "main" }}
+<article>
+  <h1>{{ .Title }}</h1>
+  {{ .Content }}
+</article>
+{{ end }}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,0 +1,38 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  line-height: 1.6;
+}
+
+header {
+  background: #333;
+  color: #fff;
+  padding: 1rem;
+}
+
+nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  gap: 1rem;
+}
+
+nav a {
+  color: #fff;
+  text-decoration: none;
+}
+
+main {
+  max-width: 800px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+}
+
+footer {
+  text-align: center;
+  padding: 1rem;
+  background: #f2f2f2;
+  color: #666;
+}


### PR DESCRIPTION
## Summary
- add base layout rendering main menu and shared stylesheet
- scaffold home, composer, and foundation pages
- include default list and single templates and centralised CSS rules

## Testing
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_68a77b6fa0408333aafeea9d7205396f