### PR TITLE
Improve layout and navigation for Hugo site

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,0 +1,19 @@
+---
+title: "Stabat Mater Collection"
+---
+
+{{< youtube BB51Wb2UvbI >}}
+
+**If you would like to support us in keeping the website ad-free, consider making a [donation](https://stabatmater.info/stabat-mater-collection-support/) or purchasing the [Stabat Mater Dolorosa book](https://www.amazon.com/Stabat-Mater-Dolorosa-Journey-Centuries/dp/B0CY8T9MG1). Thank you!**
+
+## Search the Ultimate Stabat Mater Website
+
+On the Ultimate Stabat Mater Website you will find the CD-collection of more than 300 different Stabat Mater compositions. Search for [composers](https://stabatmater.info/stabat-mater-composer/): alphabetically, chronologically, by country of origin and by duration. [Listen](https://www.youtube.com/channel/UCPUZ1hgQgIIYQeMqoJWWoXw) to the compositions and [watch](https://www.youtube.com/channel/UCPUZ1hgQgIIYQeMqoJWWoXw/featured) the videos of special performances. The site also includes [translations](https://stabatmater.info/stabat-mater-translations-and-languages/) of the original Latin poem [Stabat Mater Dolorosa](https://stabatmater.info/stabat-mater-dolorosa-about-the-poem/) in 24 different languages. See: [Latest additions](https://stabatmater.info/category/latest-addition/).
+
+## Why this Stabat Mater website?
+
+Initiator of this website, [Hans van der Velden](https://stabatmater.info/stabat-mater-foundation/), began this journey of musical discovery in 1992 with the Stabat Mater from [Haydn](https://stabatmater.info/stabat-mater-foundation/). He searched systematically and persistently for composers, performances on CD and translations of the original Latin poem. He brought the religious, literary, and musical world of the Stabat Mater to life. [We are proud](https://stabatmater.info/stabat-mater-foundation/) to continue his work.
+
+## Interested?
+
+We hope this site is helpful for music lovers, musicians, and composers! Would you like to learn more? Subscribe to the Newsletter or [read the blog](https://stabatmater.info/stabat-mater-blog/). Do you have any information about performances, recordings, videos, or CDs with Stabat Maters? [Please, let us know](https://stabatmater.info/contact/)!

--- a/content/stabat-mater-composer/_index.md
+++ b/content/stabat-mater-composer/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Composers"
+---
+
+Browse the growing directory of Stabat Mater composers. Here you can explore works alphabetically, chronologically, by country of origin and duration. More entries will appear as the migration progresses.

--- a/content/stabat-mater-foundation/_index.md
+++ b/content/stabat-mater-foundation/_index.md
@@ -1,0 +1,15 @@
+---
+title: "About the foundation"
+---
+
+<img src="https://stabatmater.info/wp-content/uploads/2015/02/Hans.jpg" alt="Stabat Mater Foundation" width="150" align="right">
+
+Hans van der Velden started collecting Stabat Maters in 1992. After five years, when he owned about 40 Stabat Mater CDs, his partner Hannie van Osnabrugge created the Ultimate Stabat Mater Website with FrontPage. The site contained all his notes on the composer, the composition, the original Latin text, and the translations. Hans continued his search for Stabat Maters and regularly updated the site with new composers and translations. Via the website Hans came into contact with music lovers, musicians, and composers from all over the world who provided him with new information about compositions and translations. The Stabat Mater collection became one of his passions. In his own words:
+
+> *When I realised, one day, that I owned several CDs with a musical setting of the Stabat Mater I decided to start a real collection... I now know about some 600 composers, who (fortunately) have not all been recorded on CD yet. Still, a substantial fraction has been released on CD and my collection grew rapidly. Beside this list of my collection of CDs I have made another list of composers, who as far as I know have not yet been recorded on CD (more than 400).* 
+>
+> *A collection invites comparing, and that is what I do. I analyse the text and note the differences, as it appears that several variations of the Stabat Mater poem exist. I listen to the music and I try to present the results in an easily surveyable way...*
+
+When Hans died on December 28th, 2005, he possessed 211 different Stabat Mater compositions on CD. After his death, his spouse continued collecting Stabat Mater compositions and managing the site. In 1998 the Dutch Stabat Mater Foundation was founded, supporting concerts in St. Petrus Church in Oirschot every year until 2018.
+
+In 2020 the Ultimate Stabat Mater Website once again got an amazing offer from the Foundation for Sacred Music to renew and improve the site to get more visitors and ensure continuity in the future. For this purpose Hannie decided in June 2020 to create the Ultimate Stabat Mater website Foundation. This foundation aims, with its unique collection and expertise, to assist composers, musicians, and music lovers anywhere in the world and to guarantee the continued existence of the unique website so that collected knowledge and expertise will not be lost.

--- a/docs/.nojekyll
+++ b/docs/.nojekyll
@@ -1,0 +1,1 @@
+# Prevent GitHub Pages from using Jekyll

--- a/docs/categories/index.html
+++ b/docs/categories/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Categories - Stabat Mater Foundation</title>
+  <link rel="stylesheet" href="https://stabatmater.info/css/style.css">
+</head>
+<body>
+  <header class="site-header">
+  <div class="branding">
+    <a href="/">
+      <img src="https://stabatmater.info/wp-content/uploads/2021/02/cropped-cropped-stabat-mater-beeld.png" alt="Stabat Mater Foundation" />
+    </a>
+    <div class="tagline">
+      <p class="site-title">The Ultimate Stabat Mater Website</p>
+      <p class="site-description">a musical journey through the ages</p>
+    </div>
+  </div>
+  <nav class="main-nav">
+    <ul>
+      
+      <li><a href="/stabat-mater-composer/">Composers</a></li>
+      
+      <li><a href="/stabat-mater-foundation/">About</a></li>
+      
+    </ul>
+  </nav>
+</header>
+
+  <main>
+    
+  <h1>Categories</h1>
+  
+  
+
+  </main>
+  <footer>
+  <p>&copy; 2025 Stabat Mater Foundation</p>
+</footer>
+
+</body>
+</html>

--- a/docs/categories/index.xml
+++ b/docs/categories/index.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Categories on Stabat Mater Foundation</title>
+    <link>https://stabatmater.info/categories/</link>
+    <description>Recent content in Categories on Stabat Mater Foundation</description>
+    <generator>Hugo -- gohugo.io</generator>
+    <language>en</language>
+    <atom:link href="https://stabatmater.info/categories/index.xml" rel="self" type="application/rss+xml" />
+  </channel>
+</rss>

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1,0 +1,79 @@
+@import url('https://fonts.googleapis.com/css2?family=Domine&family=Source+Sans+Pro:wght@400;600&display=swap');
+
+body {
+  font-family: 'Source Sans Pro', sans-serif;
+  margin: 0;
+  padding: 0;
+  line-height: 1.6;
+}
+
+.site-header {
+  background: #f8f8f8;
+  border-bottom: 4px solid #4a6572;
+}
+
+.site-header .branding {
+  max-width: 960px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem;
+}
+
+.site-header img {
+  max-height: 80px;
+  height: auto;
+}
+
+.site-title {
+  font-family: 'Domine', serif;
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.site-description {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #555;
+}
+
+.main-nav {
+  background: #4a6572;
+}
+
+.main-nav ul {
+  list-style: none;
+  margin: 0 auto;
+  padding: 0;
+  display: flex;
+  max-width: 960px;
+}
+
+.main-nav li {
+  margin: 0;
+}
+
+.main-nav a {
+  display: block;
+  padding: 0.75rem 1rem;
+  color: #fff;
+  text-decoration: none;
+}
+
+.main-nav a:hover {
+  background: #394f5a;
+}
+
+main {
+  max-width: 960px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+}
+
+footer {
+  text-align: center;
+  padding: 1rem;
+  background: #f2f2f2;
+  color: #666;
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta name="generator" content="Hugo 0.123.7">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Stabat Mater Collection - Stabat Mater Foundation</title>
+  <link rel="stylesheet" href="https://stabatmater.info/css/style.css">
+</head>
+<body>
+  <header class="site-header">
+  <div class="branding">
+    <a href="/">
+      <img src="https://stabatmater.info/wp-content/uploads/2021/02/cropped-cropped-stabat-mater-beeld.png" alt="Stabat Mater Foundation" />
+    </a>
+    <div class="tagline">
+      <p class="site-title">The Ultimate Stabat Mater Website</p>
+      <p class="site-description">a musical journey through the ages</p>
+    </div>
+  </div>
+  <nav class="main-nav">
+    <ul>
+      
+      <li><a href="/stabat-mater-composer/">Composers</a></li>
+      
+      <li><a href="/stabat-mater-foundation/">About</a></li>
+      
+    </ul>
+  </nav>
+</header>
+
+  <main>
+    
+  <h1>Stabat Mater Collection</h1>
+  
+<div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
+  <iframe src="https://www.youtube.com/embed/BB51Wb2UvbI" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" allowfullscreen title="YouTube Video"></iframe>
+</div>
+
+<p><strong>If you would like to support us in keeping the website ad-free, consider making a <a href="https://stabatmater.info/stabat-mater-collection-support/">donation</a> or purchasing the <a href="https://www.amazon.com/Stabat-Mater-Dolorosa-Journey-Centuries/dp/B0CY8T9MG1">Stabat Mater Dolorosa book</a>. Thank you!</strong></p>
+<h2 id="search-the-ultimate-stabat-mater-website">Search the Ultimate Stabat Mater Website</h2>
+<p>On the Ultimate Stabat Mater Website you will find the CD-collection of more than 300 different Stabat Mater compositions. Search for <a href="https://stabatmater.info/stabat-mater-composer/">composers</a>: alphabetically, chronologically, by country of origin and by duration. <a href="https://www.youtube.com/channel/UCPUZ1hgQgIIYQeMqoJWWoXw">Listen</a> to the compositions and <a href="https://www.youtube.com/channel/UCPUZ1hgQgIIYQeMqoJWWoXw/featured">watch</a> the videos of special performances. The site also includes <a href="https://stabatmater.info/stabat-mater-translations-and-languages/">translations</a> of the original Latin poem <a href="https://stabatmater.info/stabat-mater-dolorosa-about-the-poem/">Stabat Mater Dolorosa</a> in 24 different languages. See: <a href="https://stabatmater.info/category/latest-addition/">Latest additions</a>.</p>
+<h2 id="why-this-stabat-mater-website">Why this Stabat Mater website?</h2>
+<p>Initiator of this website, <a href="https://stabatmater.info/stabat-mater-foundation/">Hans van der Velden</a>, began this journey of musical discovery in 1992 with the Stabat Mater from <a href="https://stabatmater.info/stabat-mater-foundation/">Haydn</a>. He searched systematically and persistently for composers, performances on CD and translations of the original Latin poem. He brought the religious, literary, and musical world of the Stabat Mater to life. <a href="https://stabatmater.info/stabat-mater-foundation/">We are proud</a> to continue his work.</p>
+<h2 id="interested">Interested?</h2>
+<p>We hope this site is helpful for music lovers, musicians, and composers! Would you like to learn more? Subscribe to the Newsletter or <a href="https://stabatmater.info/stabat-mater-blog/">read the blog</a>. Do you have any information about performances, recordings, videos, or CDs with Stabat Maters? <a href="https://stabatmater.info/contact/">Please, let us know</a>!</p>
+
+  
+  <ul>
+    
+    <li><a href="/stabat-mater-foundation/">About the foundation</a></li>
+    
+    <li><a href="/stabat-mater-composer/">Composers</a></li>
+    
+  </ul>
+  
+
+  </main>
+  <footer>
+  <p>&copy; 2025 Stabat Mater Foundation</p>
+</footer>
+
+</body>
+</html>

--- a/docs/index.xml
+++ b/docs/index.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Stabat Mater Collection on Stabat Mater Foundation</title>
+    <link>https://stabatmater.info/</link>
+    <description>Recent content in Stabat Mater Collection on Stabat Mater Foundation</description>
+    <generator>Hugo -- gohugo.io</generator>
+    <language>en</language>
+    <atom:link href="https://stabatmater.info/index.xml" rel="self" type="application/rss+xml" />
+  </channel>
+</rss>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>https://stabatmater.info/stabat-mater-foundation/</loc>
+  </url><url>
+    <loc>https://stabatmater.info/categories/</loc>
+  </url><url>
+    <loc>https://stabatmater.info/stabat-mater-composer/</loc>
+  </url><url>
+    <loc>https://stabatmater.info/</loc>
+  </url><url>
+    <loc>https://stabatmater.info/tags/</loc>
+  </url>
+</urlset>

--- a/docs/stabat-mater-composer/index.html
+++ b/docs/stabat-mater-composer/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Composers - Stabat Mater Foundation</title>
+  <link rel="stylesheet" href="https://stabatmater.info/css/style.css">
+</head>
+<body>
+  <header class="site-header">
+  <div class="branding">
+    <a href="/">
+      <img src="https://stabatmater.info/wp-content/uploads/2021/02/cropped-cropped-stabat-mater-beeld.png" alt="Stabat Mater Foundation" />
+    </a>
+    <div class="tagline">
+      <p class="site-title">The Ultimate Stabat Mater Website</p>
+      <p class="site-description">a musical journey through the ages</p>
+    </div>
+  </div>
+  <nav class="main-nav">
+    <ul>
+      
+      <li><a href="/stabat-mater-composer/">Composers</a></li>
+      
+      <li><a href="/stabat-mater-foundation/">About</a></li>
+      
+    </ul>
+  </nav>
+</header>
+
+  <main>
+    
+  <h1>Composers</h1>
+  <p>Browse the growing directory of Stabat Mater composers. Here you can explore works alphabetically, chronologically, by country of origin and duration. More entries will appear as the migration progresses.</p>
+
+  
+
+  </main>
+  <footer>
+  <p>&copy; 2025 Stabat Mater Foundation</p>
+</footer>
+
+</body>
+</html>

--- a/docs/stabat-mater-composer/index.xml
+++ b/docs/stabat-mater-composer/index.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Composers on Stabat Mater Foundation</title>
+    <link>https://stabatmater.info/stabat-mater-composer/</link>
+    <description>Recent content in Composers on Stabat Mater Foundation</description>
+    <generator>Hugo -- gohugo.io</generator>
+    <language>en</language>
+    <atom:link href="https://stabatmater.info/stabat-mater-composer/index.xml" rel="self" type="application/rss+xml" />
+  </channel>
+</rss>

--- a/docs/stabat-mater-foundation/index.html
+++ b/docs/stabat-mater-foundation/index.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>About the foundation - Stabat Mater Foundation</title>
+  <link rel="stylesheet" href="https://stabatmater.info/css/style.css">
+</head>
+<body>
+  <header class="site-header">
+  <div class="branding">
+    <a href="/">
+      <img src="https://stabatmater.info/wp-content/uploads/2021/02/cropped-cropped-stabat-mater-beeld.png" alt="Stabat Mater Foundation" />
+    </a>
+    <div class="tagline">
+      <p class="site-title">The Ultimate Stabat Mater Website</p>
+      <p class="site-description">a musical journey through the ages</p>
+    </div>
+  </div>
+  <nav class="main-nav">
+    <ul>
+      
+      <li><a href="/stabat-mater-composer/">Composers</a></li>
+      
+      <li><a href="/stabat-mater-foundation/">About</a></li>
+      
+    </ul>
+  </nav>
+</header>
+
+  <main>
+    
+  <h1>About the foundation</h1>
+  <!-- raw HTML omitted -->
+<p>Hans van der Velden started collecting Stabat Maters in 1992. After five years, when he owned about 40 Stabat Mater CDs, his partner Hannie van Osnabrugge created the Ultimate Stabat Mater Website with FrontPage. The site contained all his notes on the composer, the composition, the original Latin text, and the translations. Hans continued his search for Stabat Maters and regularly updated the site with new composers and translations. Via the website Hans came into contact with music lovers, musicians, and composers from all over the world who provided him with new information about compositions and translations. The Stabat Mater collection became one of his passions. In his own words:</p>
+<blockquote>
+<p><em>When I realised, one day, that I owned several CDs with a musical setting of the Stabat Mater I decided to start a real collection&hellip; I now know about some 600 composers, who (fortunately) have not all been recorded on CD yet. Still, a substantial fraction has been released on CD and my collection grew rapidly. Beside this list of my collection of CDs I have made another list of composers, who as far as I know have not yet been recorded on CD (more than 400).</em></p>
+<p><em>A collection invites comparing, and that is what I do. I analyse the text and note the differences, as it appears that several variations of the Stabat Mater poem exist. I listen to the music and I try to present the results in an easily surveyable way&hellip;</em></p>
+</blockquote>
+<p>When Hans died on December 28th, 2005, he possessed 211 different Stabat Mater compositions on CD. After his death, his spouse continued collecting Stabat Mater compositions and managing the site. In 1998 the Dutch Stabat Mater Foundation was founded, supporting concerts in St. Petrus Church in Oirschot every year until 2018.</p>
+<p>In 2020 the Ultimate Stabat Mater Website once again got an amazing offer from the Foundation for Sacred Music to renew and improve the site to get more visitors and ensure continuity in the future. For this purpose Hannie decided in June 2020 to create the Ultimate Stabat Mater website Foundation. This foundation aims, with its unique collection and expertise, to assist composers, musicians, and music lovers anywhere in the world and to guarantee the continued existence of the unique website so that collected knowledge and expertise will not be lost.</p>
+
+  
+
+  </main>
+  <footer>
+  <p>&copy; 2025 Stabat Mater Foundation</p>
+</footer>
+
+</body>
+</html>

--- a/docs/stabat-mater-foundation/index.xml
+++ b/docs/stabat-mater-foundation/index.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>About the foundation on Stabat Mater Foundation</title>
+    <link>https://stabatmater.info/stabat-mater-foundation/</link>
+    <description>Recent content in About the foundation on Stabat Mater Foundation</description>
+    <generator>Hugo -- gohugo.io</generator>
+    <language>en</language>
+    <atom:link href="https://stabatmater.info/stabat-mater-foundation/index.xml" rel="self" type="application/rss+xml" />
+  </channel>
+</rss>

--- a/docs/tags/index.html
+++ b/docs/tags/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Tags - Stabat Mater Foundation</title>
+  <link rel="stylesheet" href="https://stabatmater.info/css/style.css">
+</head>
+<body>
+  <header class="site-header">
+  <div class="branding">
+    <a href="/">
+      <img src="https://stabatmater.info/wp-content/uploads/2021/02/cropped-cropped-stabat-mater-beeld.png" alt="Stabat Mater Foundation" />
+    </a>
+    <div class="tagline">
+      <p class="site-title">The Ultimate Stabat Mater Website</p>
+      <p class="site-description">a musical journey through the ages</p>
+    </div>
+  </div>
+  <nav class="main-nav">
+    <ul>
+      
+      <li><a href="/stabat-mater-composer/">Composers</a></li>
+      
+      <li><a href="/stabat-mater-foundation/">About</a></li>
+      
+    </ul>
+  </nav>
+</header>
+
+  <main>
+    
+  <h1>Tags</h1>
+  
+  
+
+  </main>
+  <footer>
+  <p>&copy; 2025 Stabat Mater Foundation</p>
+</footer>
+
+</body>
+</html>

--- a/docs/tags/index.xml
+++ b/docs/tags/index.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Tags on Stabat Mater Foundation</title>
+    <link>https://stabatmater.info/tags/</link>
+    <description>Recent content in Tags on Stabat Mater Foundation</description>
+    <generator>Hugo -- gohugo.io</generator>
+    <language>en</language>
+    <atom:link href="https://stabatmater.info/tags/index.xml" rel="self" type="application/rss+xml" />
+  </channel>
+</rss>

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,13 +1,14 @@
 baseURL = 'https://stabatmater.info/'
 languageCode = 'en'
 title = 'Stabat Mater Foundation'
+publishDir = 'docs'
 
 [menu]
   [[menu.main]]
     name = 'Composers'
-    url = '/stabat-mater-composer/'
+    pageRef = 'stabat-mater-composer'
     weight = 1
   [[menu.main]]
-    name = 'Foundation'
-    url = '/stabat-mater-foundation/'
+    name = 'About'
+    pageRef = 'stabat-mater-foundation'
     weight = 2

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{ block "title" . }}{{ .Title }} - {{ .Site.Title }}{{ end }}</title>
+  <link rel="stylesheet" href="{{ "css/style.css" | absURL }}">
+</head>
+<body>
+  {{ partial "header.html" . }}
+  <main>
+    {{ block "main" . }}{{ end }}
+  </main>
+  {{ partial "footer.html" . }}
+</body>
+</html>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,0 +1,11 @@
+{{ define "main" }}
+  {{ if .Title }}<h1>{{ .Title }}</h1>{{ end }}
+  {{ .Content }}
+  {{ if .Pages }}
+  <ul>
+    {{ range .Pages }}
+    <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+    {{ end }}
+  </ul>
+  {{ end }}
+{{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,0 +1,6 @@
+{{ define "main" }}
+<article>
+  <h1>{{ .Title }}</h1>
+  {{ .Content }}
+</article>
+{{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,0 +1,3 @@
+<footer>
+  <p>&copy; {{ now.Format "2006" }} {{ .Site.Title }}</p>
+</footer>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,0 +1,18 @@
+<header class="site-header">
+  <div class="branding">
+    <a href="{{ "/" | relURL }}">
+      <img src="https://stabatmater.info/wp-content/uploads/2021/02/cropped-cropped-stabat-mater-beeld.png" alt="{{ .Site.Title }}" />
+    </a>
+    <div class="tagline">
+      <p class="site-title">The Ultimate Stabat Mater Website</p>
+      <p class="site-description">a musical journey through the ages</p>
+    </div>
+  </div>
+  <nav class="main-nav">
+    <ul>
+      {{ range .Site.Menus.main }}
+      <li><a href="{{ if .Page }}{{ .Page.RelPermalink }}{{ else }}{{ .URL | relURL }}{{ end }}">{{ .Name }}</a></li>
+      {{ end }}
+    </ul>
+  </nav>
+</header>

--- a/static/.nojekyll
+++ b/static/.nojekyll
@@ -1,0 +1,1 @@
+# Prevent GitHub Pages from using Jekyll

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,0 +1,79 @@
+@import url('https://fonts.googleapis.com/css2?family=Domine&family=Source+Sans+Pro:wght@400;600&display=swap');
+
+body {
+  font-family: 'Source Sans Pro', sans-serif;
+  margin: 0;
+  padding: 0;
+  line-height: 1.6;
+}
+
+.site-header {
+  background: #f8f8f8;
+  border-bottom: 4px solid #4a6572;
+}
+
+.site-header .branding {
+  max-width: 960px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem;
+}
+
+.site-header img {
+  max-height: 80px;
+  height: auto;
+}
+
+.site-title {
+  font-family: 'Domine', serif;
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.site-description {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #555;
+}
+
+.main-nav {
+  background: #4a6572;
+}
+
+.main-nav ul {
+  list-style: none;
+  margin: 0 auto;
+  padding: 0;
+  display: flex;
+  max-width: 960px;
+}
+
+.main-nav li {
+  margin: 0;
+}
+
+.main-nav a {
+  display: block;
+  padding: 0.75rem 1rem;
+  color: #fff;
+  text-decoration: none;
+}
+
+.main-nav a:hover {
+  background: #394f5a;
+}
+
+main {
+  max-width: 960px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+}
+
+footer {
+  text-align: center;
+  padding: 1rem;
+  background: #f2f2f2;
+  color: #666;
+}


### PR DESCRIPTION
## Summary
- fix broken navigation links with `pageRef`
- add logo, tagline, and responsive navigation header
- apply site-wide styling closer to original design

## Testing
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_68a77b6fa0408333aafeea9d7205396f